### PR TITLE
Increased default font size for Input

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -327,5 +327,5 @@ TextInput.defaultProps = {
   height: 40,
   px: 2,
   fontFamily: "inter400",
-  fontSize: "14px",
+  fontSize: "16px",
 };


### PR DESCRIPTION
fixes #156

Android

<img width="348" alt="Screenshot 2021-12-28 at 11 00 59 AM" src="https://user-images.githubusercontent.com/35962711/147531450-3b93780e-7c36-4ff9-8e56-7500b2dcdac3.png">
 
iOS

<img width="318" alt="Screenshot 2021-12-28 at 11 06 19 AM" src="https://user-images.githubusercontent.com/35962711/147531795-a654ca1b-ae1e-4734-9051-f3fdecb0fecd.png">
