### PR TITLE
Moved RichText toolbar on top of editor

### DIFF
--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -92,6 +92,15 @@ export const RichTextEditor = ({
   return (
     <>
       <ScrollView {...rest?.editorWrapperStyle}>
+        {showToolbar && (
+          <Container width="100%" {...rest?.toolbarWrapperStyle}>
+            <RichToolbar
+              editor={richTextRef}
+              actions={computeToolbarActions()}
+              {...toolBarProps}
+            />
+          </Container>
+        )}
         <RichEditor
           placeholder={placeholderText}
           ref={richTextRef}
@@ -110,20 +119,6 @@ export const RichTextEditor = ({
 
         {children}
       </ScrollView>
-      {showToolbar && (
-        <Container
-          bottom={keyboardHeight}
-          position="absolute"
-          width="100%"
-          {...rest?.toolbarWrapperStyle}
-        >
-          <RichToolbar
-            editor={richTextRef}
-            actions={computeToolbarActions()}
-            {...toolBarProps}
-          />
-        </Container>
-      )}
     </>
   );
 };


### PR DESCRIPTION
fixes #221
<img width="474" alt="Screenshot 2022-04-12 at 12 11 53 PM" src="https://user-images.githubusercontent.com/35962711/162897438-c14edc4d-4a87-41df-afda-e45787af0a3e.png">
 