### PR TITLE
Fixed the issue where the Bottom tab bar was getting switched unintentionally while minimizing the app in ios.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -266,6 +266,7 @@ type InputProps = {
   autoFocus?: boolean;
   disabled?: boolean;
   noBorder?: boolean;
+  showInputAccessoryView?: boolean;
   inputProps?: RNTextInputProps;
 };
 

--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from "react";
 import Icon from "react-native-remix-icon";
 import PropTypes from "prop-types";
-import { StyleSheet, Platform } from "react-native";
+import { StyleSheet, Platform, TouchableOpacity } from "react-native";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -9,6 +9,9 @@ import Animated, {
   interpolate,
   Extrapolation,
 } from "react-native-reanimated";
+import styled from "styled-components/native";
+import { flexbox, space, border, color, layout } from "styled-system";
+
 import { Container, Typography } from "@components";
 import { ThemeContext } from "styled-components/native";
 
@@ -68,6 +71,14 @@ import { ThemeContext } from "styled-components/native";
  *
  */
 
+const StyledTouchableOpacity = styled(TouchableOpacity)`
+  ${flexbox}
+  ${space}
+  ${border}
+  ${color}
+  ${layout}
+`;
+
 function TabElement({
   isFocused,
   onPress,
@@ -113,9 +124,9 @@ function TabElement({
   });
 
   return (
-    <Container
+    <StyledTouchableOpacity
       flex={1}
-      onTouchStart={onPress}
+      onPress={onPress}
       alignItems="center"
       borderTopWidth={1}
       borderColor="background.grey200"
@@ -135,7 +146,7 @@ function TabElement({
       >
         {name}
       </Typography>
-    </Container>
+    </StyledTouchableOpacity>
   );
 }
 

--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from "react";
 import Icon from "react-native-remix-icon";
 import PropTypes from "prop-types";
-import { StyleSheet, Platform, TouchableOpacity } from "react-native";
+import { StyleSheet, Platform, TouchableWithoutFeedback } from "react-native";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -71,7 +71,7 @@ import { ThemeContext } from "styled-components/native";
  *
  */
 
-const StyledTouchableOpacity = styled(TouchableOpacity)`
+const StyledTouchableWithoutFeedback = styled(TouchableWithoutFeedback)`
   ${flexbox}
   ${space}
   ${border}
@@ -124,7 +124,7 @@ function TabElement({
   });
 
   return (
-    <StyledTouchableOpacity
+    <StyledTouchableWithoutFeedback
       flex={1}
       onPress={onPress}
       alignItems="center"
@@ -146,7 +146,7 @@ function TabElement({
       >
         {name}
       </Typography>
-    </StyledTouchableOpacity>
+    </StyledTouchableWithoutFeedback>
   );
 }
 

--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -9,8 +9,6 @@ import Animated, {
   interpolate,
   Extrapolation,
 } from "react-native-reanimated";
-import styled from "styled-components/native";
-import { flexbox, space, border, color, layout } from "styled-system";
 
 import { Container, Typography } from "@components";
 import { ThemeContext } from "styled-components/native";
@@ -71,14 +69,6 @@ import { ThemeContext } from "styled-components/native";
  *
  */
 
-const StyledTouchableWithoutFeedback = styled(TouchableWithoutFeedback)`
-  ${flexbox}
-  ${space}
-  ${border}
-  ${color}
-  ${layout}
-`;
-
 function TabElement({
   isFocused,
   onPress,
@@ -124,29 +114,30 @@ function TabElement({
   });
 
   return (
-    <StyledTouchableWithoutFeedback
-      flex={1}
-      onPress={onPress}
-      alignItems="center"
-      borderTopWidth={1}
-      borderColor="background.grey200"
-    >
-      <Container height={35} width={48} alignItems="center" mb={1}>
-        <Animated.View style={[styles.iconContainer, animatedStyles]}>
-          <Icon size={size} color={theme.colors.font.grey500} name={icon} />
-        </Animated.View>
-        <Animated.View style={[styles.iconContainer, animatedStyles2]}>
-          <Icon size={size} color={theme.colors.font.base} name={icon} />
-        </Animated.View>
-      </Container>
-      <Typography
-        color={isFocused ? tabBarActiveTintColor : tabBarInactiveTintColor}
-        fontFamily="sf500"
-        fontSize="4xs"
+    <TouchableWithoutFeedback onPress={onPress}>
+      <Container
+        flex={1}
+        alignItems="center"
+        borderTopWidth={1}
+        borderColor="background.grey200"
       >
-        {name}
-      </Typography>
-    </StyledTouchableWithoutFeedback>
+        <Container height={35} width={48} alignItems="center" mb={1}>
+          <Animated.View style={[styles.iconContainer, animatedStyles]}>
+            <Icon size={size} color={theme.colors.font.grey500} name={icon} />
+          </Animated.View>
+          <Animated.View style={[styles.iconContainer, animatedStyles2]}>
+            <Icon size={size} color={theme.colors.font.base} name={icon} />
+          </Animated.View>
+        </Container>
+        <Typography
+          color={isFocused ? tabBarActiveTintColor : tabBarInactiveTintColor}
+          fontFamily="sf500"
+          fontSize="4xs"
+        >
+          {name}
+        </Typography>
+      </Container>
+    </TouchableWithoutFeedback>
   );
 }
 

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -101,6 +101,7 @@ export const Input = props => {
     autoFocus = false,
     disabled = false,
     noBorder = false,
+    showInputAccessoryView = true,
     textAlignVertical = "top",
     ...rest
   } = props;
@@ -235,30 +236,32 @@ export const Input = props => {
             textAlignVertical={textAlignVertical}
             {...rest.inputProps}
           />
-          {rest.inputProps?.multiline && Platform.OS === "ios" && (
-            <InputAccessoryView nativeID={label}>
-              <Container
-                bg="background.white"
-                flexDirection="row"
-                p={2}
-                width={width}
-                justifyContent="flex-end"
-                alignItems="center"
-                pr={20}
-              >
-                <Button
-                  height={30}
-                  left={10}
-                  labelStyle={styles.doneButtonStyle}
-                  variant="text"
-                  onPress={() => {
-                    Keyboard.dismiss();
-                  }}
-                  label="Done"
-                />
-              </Container>
-            </InputAccessoryView>
-          )}
+          {rest.inputProps?.multiline &&
+            showInputAccessoryView &&
+            Platform.OS === "ios" && (
+              <InputAccessoryView nativeID={label}>
+                <Container
+                  bg="background.white"
+                  flexDirection="row"
+                  p={2}
+                  width={width}
+                  justifyContent="flex-end"
+                  alignItems="center"
+                  pr={20}
+                >
+                  <Button
+                    height={30}
+                    left={10}
+                    labelStyle={styles.doneButtonStyle}
+                    variant="text"
+                    onPress={() => {
+                      Keyboard.dismiss();
+                    }}
+                    label="Done"
+                  />
+                </Container>
+              </InputAccessoryView>
+            )}
         </View>
         {!!SuffixIcon && (
           <View px={2}>
@@ -324,6 +327,10 @@ Input.propTypes = {
    * Used to align the position of text in input.
    */
   textAlignVertical: PropTypes.oneOf(["auto", "top", "bottom", "center"]),
+  /**
+   * Show Input AccessoryView on iOS
+   */
+  showInputAccessoryView: PropTypes.bool,
 };
 
 export const styles = StyleSheet.create({


### PR DESCRIPTION
**Root cause of the issue** - Since we were `onTouchStart` handle for trigger the onPress, this was getting triggered even when the user tries to minimise the app especially in ios where the user swipes the screen from the bottom to minimise. 

**Fix made** - Instead of using `onTouchStart` handle, created a styled touchable component and used its `onPress` handle which will only trigger the onPress function only when pressing the button. 

**Preview**
**Before Fix**

https://user-images.githubusercontent.com/25509500/186166305-1258d7ab-edda-4d47-8a69-dbef547fa1fb.mp4



**After Fix**

https://user-images.githubusercontent.com/25509500/186166080-c6783f3d-ea8f-4bbc-ac6e-f2bf237ac182.mp4


