### PR TITLE
added styling to carousel

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -219,6 +219,7 @@ type CarouselProps = {
   renderItem: () => React.ReactNode;
   carouselRef?: React.RefObject<Carousel>;
   onSnapToItem?: (index: number) => void;
+  containerStyle: ViewProps
 };
 
 interface CheckBoxProps extends TouchableProps {

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -43,12 +43,13 @@ export const Carousel = ({
   renderItem,
   carouselRef,
   onSnapToItem,
+  containerStyle = {},
 }) => {
   const { width } = useWindowDimensions();
   const [activeIndex, setActiveIndex] = useState(0);
 
   return (
-    <Container>
+    <Container flex={1} {...containerStyle}>
       <CarouselParent
         ref={carouselRef}
         data={itemArray}
@@ -109,4 +110,5 @@ Carousel.propTypes = {
   renderItem: PropTypes.func.isRequired,
   onSnapToItem: PropTypes.func,
   carouselRef: PropTypes.object,
+  containerStyle: PropTypes.object,
 };


### PR DESCRIPTION
@sangameshsomawar _a Added container style to `Carousel`
When using `FlashList` within the `Carousel` the items were not rendering as `Carousel` didn't have styles (flex). Tried it locally and verified the fix is working.