### PR TITLE
label props in popover

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,11 +67,11 @@ const theme: {
 
 interface StyleProps
   extends FlexboxProps,
-    SpaceProps,
-    BorderProps,
-    ColorProps,
-    LayoutProps,
-    PositionProps {
+  SpaceProps,
+  BorderProps,
+  ColorProps,
+  LayoutProps,
+  PositionProps {
   borderColor?: typeof theme.colors.border;
   borderTopColor?: typeof theme.colors.border;
   borderBottomColor?: typeof theme.colors.border;
@@ -95,11 +95,11 @@ interface TextProps extends RNTextProps, StyleProps, TypographyProps {
 }
 interface TextInputProps
   extends RNTextInputAndroidProps,
-    RNTextInputIOSProps,
-    StyleProps,
-    TypographyProps {}
-interface FlatListProps extends RNFlatListProps, StyleProps {}
-interface ScrollViewProps extends RNScrollViewProps, StyleProps {}
+  RNTextInputIOSProps,
+  StyleProps,
+  TypographyProps { }
+interface FlatListProps extends RNFlatListProps, StyleProps { }
+interface ScrollViewProps extends RNScrollViewProps, StyleProps { }
 interface TouchableProps extends RippleProps, StyleProps, ButtonStyleProps {
   children?: React.ReactNode;
 }
@@ -353,11 +353,15 @@ interface ParentViewProps extends ViewProps {
   bottomInset?: boolean;
   shouldDismissKeyboardOnTap?: boolean;
 }
-
+interface PopoverItemProps {
+  Icon?: React.FC;
+  label?: string;
+  labelProps?: TypographyProps
+}
 type RNPopoverProps = typeof RNPopover.propTypes;
 interface PopoverProps extends RNPopoverProps {
   children?: React.ReactNode;
-  data?: Array<any>;
+  data?: Array<PopoverItemProps>;
   fontFamily?: typeof theme.fonts;
   fontSize?: typeof theme.fontSizes;
 }

--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -16,7 +16,7 @@ export const TouchableOpacity = styled.TouchableOpacity`
 `;
 
 const PopOverItem = ({ item, onPress, fontFamily, fontSize }) => {
-  const { Icon, label } = item;
+  const { Icon, label, labelProps } = item;
 
   return (
     <TouchableOpacity
@@ -32,6 +32,7 @@ const PopOverItem = ({ item, onPress, fontFamily, fontSize }) => {
         fontSize={fontSize}
         fontColor="font.primary"
         fontFamily={fontFamily}
+        {...labelProps}
       >
         {label}
       </Typography>


### PR DESCRIPTION
- Fixes #495 

@sangameshsomawar _a please review

**Checklist**

- [x] I have performed a self-review of my code and tested well before raising the PR.
- [x] I have made corresponding changes to the documentation and `index.d.ts`.
- [x] I've verified the change via .yalc in some neetoApp. (tested in `neetoPlanner` through `yalc`)  <!-- Might be needed in some scenarios, if you have tested in some neeto RN app then please mention it. -->

**Demo or Screenshots**

Android
![Screenshot_1663224525](https://user-images.githubusercontent.com/87293196/190341410-0825ac7f-a6be-4ff7-8ae0-f170084c66ad.png)

iOS
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-09-15 at 12 45 47](https://user-images.githubusercontent.com/87293196/190341459-e22f86f4-886c-42fa-8bc4-40c99dfd4f02.png)

IDE
Previously it was just accepting array and the type wasn't defined for `PopoverItem`. Now it's also updated.
<img width="731" alt="Screenshot 2022-09-15 at 12 56 15 PM" src="https://user-images.githubusercontent.com/87293196/190341667-74991b9a-1328-4cb4-b1b7-79ec981f943a.png">


<!-- Please describe the current behavior that you are modifying, demo with audio will be useful in most cases -->
<!-- or you can also post before and after screenshots -->


**Breaking Change**
No braking changes
<!-- In case of breaking changes, please inform  to @bigbinary/neeto-rn and explain the necessary steps to fix the break. You can explain via video or text. -->