### PR TITLE
Added searchbar props for managing the same from bottomsheet and multiselect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -179,7 +179,7 @@ interface BottomSheetProps extends ViewProps {
   onDonePress?: () => void;
   valueExtractor?: () => {};
   labelExtractor?: () => {};
-  searchbarProps?: object;
+  searchbarProps?: SearchBarProps;
 }
 
 interface ButtonProps extends TouchableProps {
@@ -328,7 +328,7 @@ interface MultiSelectProps extends ViewProps {
   maxItemSize?: number;
   moreItemLabelContainerStyle?: ViewStyle;
   moreItemLabelStyle?: TextStyle;
-  searchbarProps?: object;
+  searchbarProps?: SearchBarProps;
 }
 
 type OnBoardingProps = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -179,6 +179,7 @@ interface BottomSheetProps extends ViewProps {
   onDonePress?: () => void;
   valueExtractor?: () => {};
   labelExtractor?: () => {};
+  searchbarProps?: object;
 }
 
 interface ButtonProps extends TouchableProps {
@@ -327,6 +328,7 @@ interface MultiSelectProps extends ViewProps {
   maxItemSize?: number;
   moreItemLabelContainerStyle?: ViewStyle;
   moreItemLabelStyle?: TextStyle;
+  searchbarProps?: object;
 }
 
 type OnBoardingProps = {

--- a/src/components/BottomSheet.js
+++ b/src/components/BottomSheet.js
@@ -23,6 +23,7 @@ const Title = ({
   canSearch,
   setSearchText,
   onDonePress,
+  searchBarProps,
 }) => {
   let touchY;
 
@@ -62,7 +63,6 @@ const Title = ({
             </Touchable>
           )}
         </Container>
-
         {canSearch && (
           <SearchBar
             debounceDelay={200}
@@ -72,6 +72,7 @@ const Title = ({
               setSearchText("");
             }}
             showCancelButton={false}
+            {...searchBarProps}
           />
         )}
       </Container>
@@ -90,6 +91,7 @@ Title.propTypes = {
   canSearch: PropTypes.bool,
   setSearchText: PropTypes.func,
   onDonePress: PropTypes.func,
+  searchBarProps: PropTypes.object,
 };
 
 /**
@@ -165,6 +167,7 @@ export const BottomSheet = ({
   valueExtractor,
   selectedItem,
   onBackdropPress,
+  searchBarProps,
   ...rest
 }) => {
   const [searchText, setSearchText] = useState("");
@@ -238,6 +241,7 @@ export const BottomSheet = ({
               searchText={searchText}
               setSearchText={setSearchText}
               onDonePress={onDonePress}
+              searchBarProps={searchBarProps}
             />
           )}
 
@@ -345,6 +349,7 @@ BottomSheet.defaultProps = {
   valueExtractor: () => {},
   labelExtractor: () => {},
   onBackdropPress: () => {},
+  searchBarProps: {},
 };
 
 BottomSheet.propTypes = {
@@ -436,6 +441,10 @@ BottomSheet.propTypes = {
    * Currently selected item
    */
   selectedItem: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  /**
+   * Object to update the searchbar component
+   */
+  searchBarProps: PropTypes.object,
   /**
    * To support more Modal params.
    */

--- a/src/components/MultiSelect.js
+++ b/src/components/MultiSelect.js
@@ -207,6 +207,7 @@ export const MultiSelect = ({
   moreItemLabelStyle,
   MoreItemComponent,
   onBackdropPress,
+  searchBarProps,
   ...rest
 }) => {
   const theme = useContext(ThemeContext);
@@ -459,6 +460,7 @@ export const MultiSelect = ({
         valueExtractor={valueExtractor}
         labelExtractor={labelExtractor}
         onBackdropPress={onBackdropPress}
+        searchBarProps={searchBarProps}
       />
     </Container>
   );
@@ -628,6 +630,10 @@ MultiSelect.propTypes = {
    * Function to customize back drop press
    */
   onBackdropPress: PropTypes.func,
+  /**
+   * Object to update the searchbar component
+   */
+  searchBarProps: PropTypes.object,
 };
 
 MultiSelect.defaultProps = {
@@ -647,4 +653,5 @@ MultiSelect.defaultProps = {
   onDonePress: () => {},
   maxItemSize: 5,
   onBackdropPress: () => {},
+  searchBarProps: {},
 };

--- a/storybook/stories/MultiSelect.stories.js
+++ b/storybook/stories/MultiSelect.stories.js
@@ -73,7 +73,7 @@ export const MultiSelects = () => {
       )}
       valueExtractor={item => item?.id}
       labelExtractor={item => item?.name}
-      searchBarProps={{ placeholder: "Search Here...", debounceDelay: 3000 }}
+      searchBarProps={{ placeholder: "Search Here...", debounceDelay: 1000 }}
       // onBackdropPress={() => {}}
       // disabled
       // noResultsLabelContainerStyle={{backgroundColor:"red"}}

--- a/storybook/stories/MultiSelect.stories.js
+++ b/storybook/stories/MultiSelect.stories.js
@@ -73,6 +73,7 @@ export const MultiSelects = () => {
       )}
       valueExtractor={item => item?.id}
       labelExtractor={item => item?.name}
+      searchBarProps={{ placeholder: "Search Here...", debounceDelay: 3000 }}
       // onBackdropPress={() => {}}
       // disabled
       // noResultsLabelContainerStyle={{backgroundColor:"red"}}


### PR DESCRIPTION
- Fixes #474 

@injas-bigbinary _a please review

**Checklist**

- [X] I have performed a self-review of my code and tested well before raising the PR.
- [X] I have made corresponding changes to the documentation and `index.d.ts`.
- [ ] I've verified the change via .yalc in some neetoApp.  <!-- Might be needed in some scenarios, if you have tested in some neeto RN app then please mention it. -->

**Demo or Screenshots**
Have added the searchbarprop to both bottomSheet and MultiSelect component. The newly added prop has a propType as object and the reason for going with approach instead of specifying individuals props is because we won't have to make any changes in future even if we are adding new custom props to the Searchbar component, we can pass all those thing within this custom prop we have defined currently. 
This is how we can set the placeholder and debounce value as of now. 
```
<MultiSelect
...
...
 searchBarProps={{ placeholder: "Search Here...", debounceDelay: 1000 }}
 />
```
I have updated placeholder value in the below screenshot to `Search Here...` using this newly defined prop.
<img width="564" alt="Screenshot 2022-09-16 at 7 55 30 PM" src="https://user-images.githubusercontent.com/25509500/190662247-02efb57b-47be-4398-8e7b-862536e6e437.png">


<!-- Please describe the current behavior that you are modifying, demo with audio will be useful in most cases -->
<!-- or you can also post before and after screenshots -->


**Breaking Change**
- None
<!-- Incase of breaking changes, please inform  to @bigbinary/neeto-rn and explain the necessary steps to fix the break. You can explain via video or text. -->