### PR TITLE
Fixed the touchable area of both Input and Search Input component and fixed the RTE toolbar issue. 

### DIFF
--- a/src/components/CheckBox.js
+++ b/src/components/CheckBox.js
@@ -115,6 +115,7 @@ export const CheckBox = ({
       <Typography
         ml={2}
         fontSize="m"
+        flex={1}
         {...(checked && checkedProps.labelProps)}
         {...(!checked && unCheckedProps.labelProps)}
         {...(disabled && disabledProps.labelProps)}

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -19,6 +19,7 @@ import {
   StyleSheet,
   useWindowDimensions,
   Platform,
+  TouchableWithoutFeedback,
 } from "react-native";
 import styled, { ThemeContext } from "styled-components/native";
 import PropTypes from "prop-types";
@@ -184,101 +185,107 @@ export const Input = props => {
   };
 
   return (
-    <View>
-      <View
-        ref={containerRef}
-        borderRadius={8}
-        borderWidth={noBorder ? 0 : 1}
-        borderColor={errorMessage ? "border.danger" : "border.grey400"}
-        alignItems="center"
-        flexDirection="row"
-        justifyContent="space-between"
-        {...(!rest.inputProps?.multiline && { height: 58 })}
-        overflow="hidden"
-        {...rest.containerProps}
+    <>
+      <TouchableWithoutFeedback
+        onPress={() => {
+          inputRef.current.focus();
+        }}
       >
-        {!!PrefixIcon && (
-          <View pl={2}>
-            <PrefixIcon />
-          </View>
-        )}
-        <View flex={1} left={10}>
-          {!!label && (
-            <AnimatedLabel
-              color={disabled ? "font.grey400" : "font.grey600"}
-              position="absolute"
-              zIndex={1}
-              style={labelStyles}
-            >
-              {label}
-            </AnimatedLabel>
+        <View
+          ref={containerRef}
+          borderRadius={8}
+          borderWidth={noBorder ? 0 : 1}
+          borderColor={errorMessage ? "border.danger" : "border.grey400"}
+          alignItems="center"
+          flexDirection="row"
+          justifyContent="space-between"
+          {...(!rest.inputProps?.multiline && { height: 58 })}
+          overflow="hidden"
+          {...rest.containerProps}
+        >
+          {!!PrefixIcon && (
+            <View pl={2}>
+              <PrefixIcon />
+            </View>
           )}
-          <TextInput
-            ref={inputRef}
-            value={value}
-            returnKeyType={rest.inputProps?.multiline ? "default" : "done"}
-            onChangeText={onChangeText}
-            autoFocus={autoFocus}
-            editable={!disabled}
-            onFocus={() => {
-              handleFocusBlur(true);
-            }}
-            onBlur={() => {
-              onBlur();
-              handleFocusBlur(false);
-            }}
-            inputAccessoryViewID={label}
-            color={disabled ? "font.grey500" : "font.primary"}
-            fontSize={17}
-            pr={3}
-            top={0}
-            zIndex={2}
-            autoCapitalize="none"
-            mt={10}
-            pb={3}
-            pt={1}
-            textAlignVertical={textAlignVertical}
-            {...rest.inputProps}
-          />
-          {rest.inputProps?.multiline &&
-            showInputAccessoryView &&
-            Platform.OS === "ios" && (
-              <InputAccessoryView nativeID={label}>
-                <Container
-                  bg="background.white"
-                  flexDirection="row"
-                  p={2}
-                  width={width}
-                  justifyContent="flex-end"
-                  alignItems="center"
-                  pr={20}
-                >
-                  <Button
-                    height={30}
-                    left={10}
-                    labelStyle={styles.doneButtonStyle}
-                    variant="text"
-                    onPress={() => {
-                      Keyboard.dismiss();
-                    }}
-                    label="Done"
-                  />
-                </Container>
-              </InputAccessoryView>
+          <View flex={1} left={10}>
+            {!!label && (
+              <AnimatedLabel
+                color={disabled ? "font.grey400" : "font.grey600"}
+                position="absolute"
+                zIndex={1}
+                style={labelStyles}
+              >
+                {label}
+              </AnimatedLabel>
             )}
-        </View>
-        {!!SuffixIcon && (
-          <View px={2}>
-            <SuffixIcon />
+            <TextInput
+              ref={inputRef}
+              value={value}
+              returnKeyType={rest.inputProps?.multiline ? "default" : "done"}
+              onChangeText={onChangeText}
+              autoFocus={autoFocus}
+              editable={!disabled}
+              onFocus={() => {
+                handleFocusBlur(true);
+              }}
+              onBlur={() => {
+                onBlur();
+                handleFocusBlur(false);
+              }}
+              inputAccessoryViewID={label}
+              color={disabled ? "font.grey500" : "font.primary"}
+              fontSize={17}
+              pr={3}
+              top={0}
+              zIndex={2}
+              autoCapitalize="none"
+              mt={10}
+              pb={3}
+              pt={1}
+              textAlignVertical={textAlignVertical}
+              {...rest.inputProps}
+            />
+            {rest.inputProps?.multiline &&
+              showInputAccessoryView &&
+              Platform.OS === "ios" && (
+                <InputAccessoryView nativeID={label}>
+                  <Container
+                    bg="background.white"
+                    flexDirection="row"
+                    p={2}
+                    width={width}
+                    justifyContent="flex-end"
+                    alignItems="center"
+                    pr={20}
+                  >
+                    <Button
+                      height={30}
+                      left={10}
+                      labelStyle={styles.doneButtonStyle}
+                      variant="text"
+                      onPress={() => {
+                        Keyboard.dismiss();
+                      }}
+                      label="Done"
+                    />
+                  </Container>
+                </InputAccessoryView>
+              )}
           </View>
-        )}
-      </View>
+          {!!SuffixIcon && (
+            <View px={2}>
+              <SuffixIcon />
+            </View>
+          )}
+        </View>
+      </TouchableWithoutFeedback>
       {!!errorMessage && (
         <Typography pt={2} color="font.danger">
           {errorMessage}
         </Typography>
       )}
-    </View>
+    </>
   );
 };
 

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -188,7 +188,9 @@ export const Input = props => {
     <>
       <TouchableWithoutFeedback
         onPress={() => {
-          inputRef.current.focus();
+          if (!inputRef?.current?.isFocused()) {
+            inputRef?.current?.focus();
+          }
         }}
       >
         <View

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -104,6 +104,7 @@ export const RadioButton = ({
       <Typography
         ml={2}
         fontSize="m"
+        flex={1}
         {...(selected && selectedProps.labelProps)}
         {...(!selected && unselectedProps.labelProps)}
         {...(disabled && disabledProps.labelProps)}

--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -82,7 +82,7 @@ export const RichTextEditor = ({
 }) => {
   const richTextRef = useRef();
   const keyboardHeight = useKeyboard();
-  const [toolbarVisible, setToolbar] = useState(true);
+  const [toolbarVisible, setToolbar] = useState(false);
   const showToolbar = keyboardHeight > 0 && toolbarVisible;
 
   const computeToolbarActions = () => {

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Animated } from "react-native";
+import { Animated, TouchableWithoutFeedback } from "react-native";
 import {
   flexbox,
   space,
@@ -98,43 +98,49 @@ export const SearchBar = props => {
 
   return (
     <Container flexDirection="row" alignItems="center">
-      <Container
-        height={42}
-        flex={1}
-        borderWidth={1}
-        borderColor={theme.colors.border.grey400}
-        borderRadius={8}
-        flexDirection="row"
-        alignItems="center"
-        {...rest.containerProps}
+      <TouchableWithoutFeedback
+        onPress={() => {
+          inputRef.current.focus();
+        }}
       >
-        <Container px={10}>
-          <Icon
-            name="ri-search-line"
-            size={20}
-            color={theme.colors.font.grey600}
+        <Container
+          height={42}
+          flex={1}
+          borderWidth={1}
+          borderColor={theme.colors.border.grey400}
+          borderRadius={8}
+          flexDirection="row"
+          alignItems="center"
+          {...rest.containerProps}
+        >
+          <Container px={10}>
+            <Icon
+              name="ri-search-line"
+              size={20}
+              color={theme.colors.font.grey600}
+            />
+          </Container>
+          <TextInput
+            ref={inputRef}
+            value={searchText}
+            onChangeText={setSearchText}
+            onFocus={() => {
+              animateSearchInput(1);
+            }}
+            onBlur={() => {
+              if (!searchText) animateSearchInput(0);
+            }}
+            placeholder={placeholder}
+            fontSize={16}
+            flex={1}
+            placeholderTextColor={theme.colors.font.grey600}
+            color="font.primary"
+            autoCapitalize="none"
+            returnKeyType="search"
+            {...rest.searchbarProps}
           />
         </Container>
-        <TextInput
-          ref={inputRef}
-          value={searchText}
-          onChangeText={setSearchText}
-          onFocus={() => {
-            animateSearchInput(1);
-          }}
-          onBlur={() => {
-            if (!searchText) animateSearchInput(0);
-          }}
-          placeholder={placeholder}
-          fontSize={16}
-          flex={1}
-          placeholderTextColor={theme.colors.font.grey600}
-          color="font.primary"
-          autoCapitalize="none"
-          returnKeyType="search"
-          {...rest.searchbarProps}
-        />
-      </Container>
+      </TouchableWithoutFeedback>
       {showCancelButton && (
         <Animated.View
           style={{

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -100,7 +100,9 @@ export const SearchBar = props => {
     <Container flexDirection="row" alignItems="center">
       <TouchableWithoutFeedback
         onPress={() => {
-          inputRef.current.focus();
+          if (!inputRef?.current?.isFocused()) {
+            inputRef?.current?.focus();
+          }
         }}
       >
         <Container


### PR DESCRIPTION
- Fixes #486
- Fixes #490 
- Fixes #472 

@sangameshsomawar _a please review

**Checklist**

- [X] I have performed a self-review of my code and tested well before raising the PR.
- [ ] I have made corresponding changes to the documentation and `index.d.ts`. 
- [X] I've verified the change via .yalc in some neetoApp.  <!-- Might be needed in some scenarios, if you have tested in some neeto RN app then please mention it. -->

**Demo or Screenshots**
For first issue - 
- Have added `TouchableWithoutFeedback` instead of the `Touchable` component from neeto-ui-rn, as we need to support nested click handles on right/left icons if we are specifying any. Since we don't want to have any  touch effect for Input component, thought of going with `TouchableWithoutFeedback`.

Second issue -  
- The issue was because the initial state of the keyboard was always set to true. Thus when the keyboard was opened the `showToolbar` value was becoming true and showing the RTE toolbar even though the user clicked on a different Input component. 

Third issue - 
- Just needed to add `flex:1` so that we takes the full available space and then wraps to the next line. The issue was only `checkbox` and `radiobutton` so have added the fix in the respective components. 

Demo - [Video](https://vimeo.com/751982011/2df6a4b4ec)

**Breaking Change**
- None
<!-- Incase of breaking changes, please inform  to @bigbinary/neeto-rn and explain the necessary steps to fix the break. You can explain via video or text. -->