### PR TITLE
Add Ripple component with fixed TouchableWithoutFeedback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,6 @@ import {
   ToastShowParams,
   ToastConfig,
 } from "react-native-toast-message";
-import { RippleProps } from "react-native-material-ripple";
 import { FastImageProps } from "react-native-fast-image";
 
 import { theme as themeDef } from "./src/theme";
@@ -106,7 +105,7 @@ interface TouchableOpacityProps
     ButtonStyleProps {
   children?: React.ReactNode;
 }
-interface TouchableProps extends RippleProps, StyleProps, ButtonStyleProps {
+interface TouchableProps extends StyleProps, ButtonStyleProps {
   children?: React.ReactNode;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,8 +105,22 @@ interface TouchableOpacityProps
     ButtonStyleProps {
   children?: React.ReactNode;
 }
+
+interface RipplePropTypes {
+  isCentered?: boolean;
+  isSequential?: boolean;
+  shouldFade?: boolean;
+  shouldOverflowContainer?: boolean;
+  color?: string;
+  opacity?: number;
+  duration?: number;
+  size?: number;
+  containerBorderRadius?: number;
+}
+
 interface TouchableProps extends StyleProps, ButtonStyleProps {
   children?: React.ReactNode;
+  rippleConfig?: RipplePropTypes;
 }
 
 interface AccordionProps extends ViewProps {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "react-content-loader": "^6.2.0",
     "react-native-calendars": "^1.1285.0",
     "react-native-gesture-handler": "^2.4.0",
-    "react-native-material-ripple": "^0.9.1",
     "react-native-modal": "^13.0.0",
     "react-native-pell-rich-editor": "^1.8.6",
     "react-native-popover-view": "^4.1.0",

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -85,7 +85,7 @@ export const Button = ({
 }) => {
   const theme = useContext(ThemeContext);
   const width = variant === "text" || variant === "danger-text" ? null : "100%";
-  const rippleOutsideContainer =
+  const shouldOverflowContainer =
     variant === "text" || variant === "danger-text";
 
   const getButtonColors = () => {
@@ -167,9 +167,11 @@ export const Button = ({
       height={moderateScale(48)}
       justifyContent="center"
       opacity={renderOpacity()}
-      rippleColor={getButtonColors().ripple}
-      rippleOutsideContainer={rippleOutsideContainer}
       width={width}
+      rippleConfig={{
+        color: getButtonColors().ripple,
+        shouldOverflowContainer,
+      }}
       {...rest}
     >
       {isLoading ? (

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -85,8 +85,6 @@ export const Button = ({
 }) => {
   const theme = useContext(ThemeContext);
   const width = variant === "text" || variant === "danger-text" ? null : "100%";
-  const shouldOverflowContainer =
-    variant === "text" || variant === "danger-text";
 
   const getButtonColors = () => {
     switch (variant) {
@@ -167,11 +165,9 @@ export const Button = ({
       height={moderateScale(48)}
       justifyContent="center"
       opacity={renderOpacity()}
+      px={width === null ? moderateScale(8) : undefined}
+      rippleConfig={{ color: getButtonColors().ripple }}
       width={width}
-      rippleConfig={{
-        color: getButtonColors().ripple,
-        shouldOverflowContainer,
-      }}
       {...rest}
     >
       {isLoading ? (
@@ -182,7 +178,7 @@ export const Button = ({
               color={color || getButtonColors().color}
               fontFamily={fontFamily || theme.fonts.sf500}
               fontSize={fontSize}
-              mx={moderateScale(2)}
+              ml={moderateScale(8)}
               textAlign="center"
               {...labelStyle}
             >

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -85,6 +85,8 @@ export const Button = ({
 }) => {
   const theme = useContext(ThemeContext);
   const width = variant === "text" || variant === "danger-text" ? null : "100%";
+  const rippleVisibleOutsideContainer =
+    variant === "text" || variant === "danger-text";
 
   const getButtonColors = () => {
     switch (variant) {
@@ -166,6 +168,7 @@ export const Button = ({
       justifyContent="center"
       opacity={renderOpacity()}
       rippleColor={getButtonColors().ripple}
+      rippleVisibleOutsideContainer={rippleVisibleOutsideContainer}
       width={width}
       {...rest}
     >

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -85,7 +85,7 @@ export const Button = ({
 }) => {
   const theme = useContext(ThemeContext);
   const width = variant === "text" || variant === "danger-text" ? null : "100%";
-  const rippleVisibleOutsideContainer =
+  const rippleOutsideContainer =
     variant === "text" || variant === "danger-text";
 
   const getButtonColors = () => {
@@ -168,7 +168,7 @@ export const Button = ({
       justifyContent="center"
       opacity={renderOpacity()}
       rippleColor={getButtonColors().ripple}
-      rippleVisibleOutsideContainer={rippleVisibleOutsideContainer}
+      rippleOutsideContainer={rippleOutsideContainer}
       width={width}
       {...rest}
     >

--- a/src/components/Ripple.jsx
+++ b/src/components/Ripple.jsx
@@ -6,7 +6,6 @@ import {
   Platform,
   I18nManager,
   StyleSheet,
-  Pressable,
 } from "react-native";
 
 import PropTypes from "prop-types";
@@ -18,7 +17,7 @@ const radius = moderateScale(10);
 
 export default class Ripple extends PureComponent {
   static defaultProps = {
-    ...Pressable.defaultProps,
+    ...TouchableWithoutFeedback.defaultProps,
 
     rippleColor: "rgb(0, 0, 0)",
     rippleOpacity: 0.3,
@@ -28,7 +27,7 @@ export default class Ripple extends PureComponent {
     rippleCentered: false,
     rippleSequential: false,
     rippleFades: true,
-    rippleVisibleOutsideContainer: false,
+    rippleOutsideContainer: false,
     disabled: false,
 
     onRippleAnimation: (animation, onComplete) => animation.start(onComplete),
@@ -36,7 +35,7 @@ export default class Ripple extends PureComponent {
 
   static propTypes = {
     ...Animated.View.propTypes,
-    ...Pressable.propTypes,
+    ...TouchableWithoutFeedback.propTypes,
 
     rippleColor: PropTypes.string,
     rippleOpacity: PropTypes.number,
@@ -46,7 +45,7 @@ export default class Ripple extends PureComponent {
     rippleCentered: PropTypes.bool,
     rippleSequential: PropTypes.bool,
     rippleFades: PropTypes.bool,
-    rippleVisibleOutsideContainer: PropTypes.bool,
+    rippleOutsideContainer: PropTypes.bool,
     disabled: PropTypes.bool,
 
     onRippleAnimation: PropTypes.func,
@@ -217,6 +216,7 @@ export default class Ripple extends PureComponent {
       pressRetentionOffset,
       children,
       rippleContainerBorderRadius,
+      rippleOutsideContainer,
       testID,
       nativeID,
       accessible,
@@ -254,10 +254,7 @@ export default class Ripple extends PureComponent {
         <Animated.View {...props} collapsable={false} pointerEvents="box-only">
           {children}
           <View
-            style={[
-              styles.container(this.props.rippleVisibleOutsideContainer),
-              containerStyle,
-            ]}
+            style={[styles.container(rippleOutsideContainer), containerStyle]}
           >
             {ripples.map(this.renderRipple)}
           </View>
@@ -268,10 +265,10 @@ export default class Ripple extends PureComponent {
 }
 
 const styles = StyleSheet.create({
-  container: rippleVisibleOutsideContainer => ({
+  container: rippleOutsideContainer => ({
     ...StyleSheet.absoluteFillObject,
     backgroundColor: "transparent",
-    overflow: rippleVisibleOutsideContainer ? "visible" : "hidden",
+    overflow: rippleOutsideContainer ? "visible" : "hidden",
   }),
   ripple: {
     width: radius * 2,

--- a/src/components/Ripple.jsx
+++ b/src/components/Ripple.jsx
@@ -1,0 +1,283 @@
+import React, { PureComponent } from "react";
+import {
+  View,
+  Animated,
+  Easing,
+  Platform,
+  I18nManager,
+  StyleSheet,
+  Pressable,
+} from "react-native";
+
+import PropTypes from "prop-types";
+import { moderateScale } from "react-native-size-matters";
+
+import TouchableWithoutFeedback from "./TouchableWithoutFeedback";
+
+const radius = moderateScale(10);
+
+export default class Ripple extends PureComponent {
+  static defaultProps = {
+    ...Pressable.defaultProps,
+
+    rippleColor: "rgb(0, 0, 0)",
+    rippleOpacity: 0.3,
+    rippleDuration: 400,
+    rippleSize: 0,
+    rippleContainerBorderRadius: 0,
+    rippleCentered: false,
+    rippleSequential: false,
+    rippleFades: true,
+    rippleVisibleOutsideContainer: false,
+    disabled: false,
+
+    onRippleAnimation: (animation, onComplete) => animation.start(onComplete),
+  };
+
+  static propTypes = {
+    ...Animated.View.propTypes,
+    ...Pressable.propTypes,
+
+    rippleColor: PropTypes.string,
+    rippleOpacity: PropTypes.number,
+    rippleDuration: PropTypes.number,
+    rippleSize: PropTypes.number,
+    rippleContainerBorderRadius: PropTypes.number,
+    rippleCentered: PropTypes.bool,
+    rippleSequential: PropTypes.bool,
+    rippleFades: PropTypes.bool,
+    rippleVisibleOutsideContainer: PropTypes.bool,
+    disabled: PropTypes.bool,
+
+    onRippleAnimation: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.onLayout = this.onLayout.bind(this);
+    this.onPress = this.onPress.bind(this);
+    this.onPressIn = this.onPressIn.bind(this);
+    this.onPressOut = this.onPressOut.bind(this);
+    this.onLongPress = this.onLongPress.bind(this);
+    this.onAnimationEnd = this.onAnimationEnd.bind(this);
+
+    this.renderRipple = this.renderRipple.bind(this);
+
+    this.unique = 0;
+    this.mounted = false;
+
+    this.state = {
+      width: 0,
+      height: 0,
+      ripples: [],
+    };
+  }
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  onLayout(event) {
+    const { width, height } = event.nativeEvent.layout;
+    const { onLayout } = this.props;
+
+    if ("function" === typeof onLayout) {
+      onLayout(event);
+    }
+
+    this.setState({ width, height });
+  }
+
+  onPress(event) {
+    const { ripples } = this.state;
+    const { onPress, rippleSequential } = this.props;
+
+    if (!rippleSequential || !ripples.length) {
+      if ("function" === typeof onPress) {
+        requestAnimationFrame(() => onPress(event));
+      }
+
+      this.startRipple(event);
+    }
+  }
+
+  onLongPress(event) {
+    const { onLongPress } = this.props;
+
+    if ("function" === typeof onLongPress) {
+      requestAnimationFrame(() => onLongPress(event));
+    }
+
+    this.startRipple(event);
+  }
+
+  onPressIn(event) {
+    const { onPressIn } = this.props;
+
+    if ("function" === typeof onPressIn) {
+      onPressIn(event);
+    }
+  }
+
+  onPressOut(event) {
+    const { onPressOut } = this.props;
+
+    if ("function" === typeof onPressOut) {
+      onPressOut(event);
+    }
+  }
+
+  onAnimationEnd() {
+    if (this.mounted) {
+      this.setState(({ ripples }) => ({ ripples: ripples.slice(1) }));
+    }
+  }
+
+  startRipple(event) {
+    const { width, height } = this.state;
+    const { rippleDuration, rippleCentered, rippleSize, onRippleAnimation } =
+      this.props;
+
+    const w2 = 0.5 * width;
+    const h2 = 0.5 * height;
+
+    const { locationX, locationY } = rippleCentered
+      ? { locationX: w2, locationY: h2 }
+      : event.nativeEvent;
+
+    const offsetX = Math.abs(w2 - locationX);
+    const offsetY = Math.abs(h2 - locationY);
+
+    const size =
+      rippleSize > 0
+        ? 0.5 * rippleSize
+        : Math.sqrt(Math.pow(w2 + offsetX, 2) + Math.pow(h2 + offsetY, 2));
+
+    const ripple = {
+      unique: this.unique++,
+      progress: new Animated.Value(0),
+      locationX,
+      locationY,
+      size,
+    };
+
+    const animation = Animated.timing(ripple.progress, {
+      toValue: 1,
+      easing: Easing.out(Easing.ease),
+      duration: rippleDuration,
+      useNativeDriver: true,
+    });
+
+    onRippleAnimation(animation, this.onAnimationEnd);
+
+    this.setState(({ ripples }) => ({ ripples: ripples.concat(ripple) }));
+  }
+
+  renderRipple({ unique, progress, locationX, locationY, size }) {
+    const { rippleColor, rippleOpacity, rippleFades } = this.props;
+
+    const rippleStyle = {
+      top: locationY - radius,
+      [I18nManager.isRTL ? "right" : "left"]: locationX - radius,
+      backgroundColor: rippleColor,
+
+      transform: [
+        {
+          scale: progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0.5 / radius, size / radius],
+          }),
+        },
+      ],
+
+      opacity: rippleFades
+        ? progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [rippleOpacity, 0],
+          })
+        : rippleOpacity,
+    };
+
+    return <Animated.View key={unique} style={[styles.ripple, rippleStyle]} />;
+  }
+
+  render() {
+    const { ripples } = this.state;
+    const {
+      delayLongPress,
+      delayPressIn,
+      delayPressOut,
+      disabled,
+      hitSlop,
+      pressRetentionOffset,
+      children,
+      rippleContainerBorderRadius,
+      testID,
+      nativeID,
+      accessible,
+      accessibilityHint,
+      accessibilityLabel,
+      ...props
+    } = this.props;
+
+    const touchableProps = {
+      delayLongPress,
+      delayPressIn,
+      delayPressOut,
+      disabled,
+      hitSlop,
+      pressRetentionOffset,
+      testID,
+      accessible,
+      accessibilityHint,
+      accessibilityLabel,
+      onLayout: this.onLayout,
+      onPress: this.onPress,
+      onLongPress: this.onLongPress,
+      onPressIn: this.onPressIn,
+      onPressOut: this.onPressOut,
+
+      ...("web" !== Platform.OS ? { nativeID } : null),
+    };
+
+    const containerStyle = {
+      borderRadius: rippleContainerBorderRadius,
+    };
+
+    return (
+      <TouchableWithoutFeedback {...touchableProps}>
+        <Animated.View {...props} collapsable={false} pointerEvents="box-only">
+          {children}
+          <View
+            style={[
+              styles.container(this.props.rippleVisibleOutsideContainer),
+              containerStyle,
+            ]}
+          >
+            {ripples.map(this.renderRipple)}
+          </View>
+        </Animated.View>
+      </TouchableWithoutFeedback>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: rippleVisibleOutsideContainer => ({
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "transparent",
+    overflow: rippleVisibleOutsideContainer ? "visible" : "hidden",
+  }),
+  ripple: {
+    width: radius * 2,
+    height: radius * 2,
+    borderRadius: radius,
+    overflow: "hidden",
+    position: "absolute",
+  },
+});

--- a/src/components/SocialButton.jsx
+++ b/src/components/SocialButton.jsx
@@ -54,7 +54,7 @@ export const SocialButton = ({
       disabled={disabled}
       height={moderateScale(48)}
       justifyContent="center"
-      rippleColor={theme.colors.background.grey800}
+      rippleConfig={{ color: theme.colors.background.grey800 }}
       width="100%"
       {...rest}
     >

--- a/src/components/Touchable.jsx
+++ b/src/components/Touchable.jsx
@@ -82,18 +82,17 @@ export const Touchable = React.forwardRef((props, ref) => {
   const rippleProps = {
     ...defaultRippleConfig,
     rippleCentered:
-      rippleConfig?.isCentered ?? defaultRippleConfig.rippleCentered,
+      rippleConfig.isCentered ?? defaultRippleConfig.rippleCentered,
     rippleSequential:
-      rippleConfig?.isSequential ?? defaultRippleConfig.rippleSequential,
-    rippleFades: rippleConfig?.shouldFade ?? defaultRippleConfig.rippleFades,
+      rippleConfig.isSequential ?? defaultRippleConfig.rippleSequential,
+    rippleFades: rippleConfig.shouldFade ?? defaultRippleConfig.rippleFades,
     rippleOutsideContainer:
-      rippleConfig?.shouldOverflowContainer ??
+      rippleConfig.shouldOverflowContainer ??
       defaultRippleConfig.rippleOutsideContainer,
-    rippleColor: rippleConfig?.color ?? defaultRippleConfig.rippleColor,
-    rippleOpacity: rippleConfig?.opacity ?? defaultRippleConfig.rippleOpacity,
-    rippleDuration:
-      rippleConfig?.duration ?? defaultRippleConfig.rippleDuration,
-    rippleSize: rippleConfig?.size ?? defaultRippleConfig.rippleSize,
+    rippleColor: rippleConfig.color ?? defaultRippleConfig.rippleColor,
+    rippleOpacity: rippleConfig.opacity ?? defaultRippleConfig.rippleOpacity,
+    rippleDuration: rippleConfig.duration ?? defaultRippleConfig.rippleDuration,
+    rippleSize: rippleConfig.size ?? defaultRippleConfig.rippleSize,
     rippleContainerBorderRadius: rest.borderRadius ? rest.borderRadius : 0,
   };
 
@@ -125,6 +124,10 @@ Touchable.propTypes = {
     size: PropTypes.number,
     containerBorderRadius: PropTypes.number,
   }),
+};
+
+Touchable.defaultProps = {
+  rippleConfig: {},
 };
 
 Touchable.displayName = "Touchable";

--- a/src/components/Touchable.jsx
+++ b/src/components/Touchable.jsx
@@ -63,19 +63,37 @@ const StyledRipple = styled(Ripple)`
  *
  */
 
+const defaultRippleConfig = {
+  rippleCentered: false,
+  rippleSequential: false,
+  rippleFades: true,
+  rippleOutsideContainer: false,
+  rippleColor: "#000",
+  rippleOpacity: 0.09,
+  rippleDuration: 600,
+  rippleSize: 0,
+  rippleContainerBorderRadius: 0,
+};
+
 export const Touchable = React.forwardRef((props, ref) => {
   const { children, elevation, rippleConfig, ...rest } = props;
   const shadowStyles = elevation ? getShadowStyles(elevation) : {};
 
   const rippleProps = {
-    rippleCentered: rippleConfig.isCentered,
-    rippleSequential: rippleConfig.isSequential,
-    rippleFades: rippleConfig.shouldFade,
-    rippleOutsideContainer: rippleConfig.shouldOverflowContainer,
-    rippleColor: rippleConfig.color,
-    rippleOpacity: rippleConfig.opacity,
-    rippleDuration: rippleConfig.duration,
-    rippleSize: rippleConfig.size,
+    ...defaultRippleConfig,
+    rippleCentered:
+      rippleConfig?.isCentered ?? defaultRippleConfig.rippleCentered,
+    rippleSequential:
+      rippleConfig?.isSequential ?? defaultRippleConfig.rippleSequential,
+    rippleFades: rippleConfig?.shouldFade ?? defaultRippleConfig.rippleFades,
+    rippleOutsideContainer:
+      rippleConfig?.shouldOverflowContainer ??
+      defaultRippleConfig.rippleOutsideContainer,
+    rippleColor: rippleConfig?.color ?? defaultRippleConfig.rippleColor,
+    rippleOpacity: rippleConfig?.opacity ?? defaultRippleConfig.rippleOpacity,
+    rippleDuration:
+      rippleConfig?.duration ?? defaultRippleConfig.rippleDuration,
+    rippleSize: rippleConfig?.size ?? defaultRippleConfig.rippleSize,
     rippleContainerBorderRadius: rest.borderRadius ? rest.borderRadius : 0,
   };
 
@@ -107,20 +125,6 @@ Touchable.propTypes = {
     size: PropTypes.number,
     containerBorderRadius: PropTypes.number,
   }),
-};
-
-Touchable.defaultProps = {
-  rippleConfig: {
-    isCentered: false,
-    isSequential: false,
-    shouldFade: true,
-    shouldOverflowContainer: false,
-    color: "#000",
-    opacity: 0.09,
-    duration: 600,
-    size: 0,
-    containerBorderRadius: 0,
-  },
 };
 
 Touchable.displayName = "Touchable";

--- a/src/components/Touchable.jsx
+++ b/src/components/Touchable.jsx
@@ -2,7 +2,6 @@ import * as React from "react";
 
 import propTypes from "@styled-system/prop-types";
 import PropTypes from "prop-types";
-import Ripple from "react-native-material-ripple";
 import styled from "styled-components/native";
 import {
   flexbox,
@@ -12,6 +11,8 @@ import {
   color,
   layout,
 } from "styled-system";
+
+import Ripple from "./Ripple";
 
 import { getShadowStyles } from "../utils/utils";
 

--- a/src/components/Touchable.jsx
+++ b/src/components/Touchable.jsx
@@ -26,7 +26,7 @@ const StyledRipple = styled(Ripple)`
 `;
 
 /**
- * Touchable component is a wrapper over https://github.com/n4kz/react-native-material-ripple.
+ * Touchable component is a wrapper over Ripple.
  *
  * This component supports below props categories from [styled-system ](/styled-system).
  * <ul>
@@ -49,9 +49,11 @@ const StyledRipple = styled(Ripple)`
  *       bg="background.primary"
  *       width="100px"
  *       height="30px"
- *       rippleOpacity = {0.09}
- *       rippleDuration = {600}
- *       rippleContainerBorderRadius = {moderateScale(50)}
+ *       rippleConfig={{
+ *          opacity: 0.09,
+ *          duration: 600,
+ *          containerBorderRadius: moderateScale(50),
+ *       }}
  *     >
  *       <Typography fontSize="10px">This is wrapped in Touchable component</Typography>
  *     </Touchable>
@@ -65,8 +67,20 @@ export const Touchable = React.forwardRef((props, ref) => {
   const { children, elevation, rippleConfig, ...rest } = props;
   const shadowStyles = elevation ? getShadowStyles(elevation) : {};
 
+  const rippleProps = {
+    rippleCentered: rippleConfig.isCentered,
+    rippleSequential: rippleConfig.isSequential,
+    rippleFades: rippleConfig.shouldFade,
+    rippleOutsideContainer: rippleConfig.shouldOverflowContainer,
+    rippleColor: rippleConfig.color,
+    rippleOpacity: rippleConfig.opacity,
+    rippleDuration: rippleConfig.duration,
+    rippleSize: rippleConfig.size,
+    rippleContainerBorderRadius: rest.borderRadius ? rest.borderRadius : 0,
+  };
+
   return (
-    <StyledRipple ref={ref} style={shadowStyles} {...rest} {...rippleConfig}>
+    <StyledRipple ref={ref} style={shadowStyles} {...rippleProps} {...rest}>
       {children}
     </StyledRipple>
   );
@@ -80,9 +94,33 @@ Touchable.propTypes = {
   ...propTypes.color,
   ...propTypes.buttonStyle,
 
-  children: PropTypes.node,
+  children: PropTypes.node.isRequired,
   elevation: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  rippleConfig: Ripple.propTypes,
+  rippleConfig: PropTypes.shape({
+    isCentered: PropTypes.bool,
+    isSequential: PropTypes.bool,
+    shouldFade: PropTypes.bool,
+    shouldOverflowContainer: PropTypes.bool,
+    color: PropTypes.string,
+    opacity: PropTypes.number,
+    duration: PropTypes.number,
+    size: PropTypes.number,
+    containerBorderRadius: PropTypes.number,
+  }),
+};
+
+Touchable.defaultProps = {
+  rippleConfig: {
+    isCentered: false,
+    isSequential: false,
+    shouldFade: true,
+    shouldOverflowContainer: false,
+    color: "#000",
+    opacity: 0.09,
+    duration: 600,
+    size: 0,
+    containerBorderRadius: 0,
+  },
 };
 
 Touchable.displayName = "Touchable";

--- a/src/components/Touchable.jsx
+++ b/src/components/Touchable.jsx
@@ -62,18 +62,11 @@ const StyledRipple = styled(Ripple)`
  */
 
 export const Touchable = React.forwardRef((props, ref) => {
-  const { children, elevation, ...rest } = props;
+  const { children, elevation, rippleConfig, ...rest } = props;
   const shadowStyles = elevation ? getShadowStyles(elevation) : {};
 
   return (
-    <StyledRipple
-      ref={ref}
-      rippleContainerBorderRadius={rest.borderRadius ? rest.borderRadius : 0}
-      rippleDuration={600}
-      rippleOpacity={0.09}
-      style={shadowStyles}
-      {...rest}
-    >
+    <StyledRipple ref={ref} style={shadowStyles} {...rest} {...rippleConfig}>
       {children}
     </StyledRipple>
   );
@@ -89,6 +82,7 @@ Touchable.propTypes = {
 
   children: PropTypes.node,
   elevation: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  rippleConfig: Ripple.propTypes,
 };
 
 Touchable.displayName = "Touchable";

--- a/src/components/TouchableWithoutFeedback.jsx
+++ b/src/components/TouchableWithoutFeedback.jsx
@@ -40,10 +40,12 @@ const TouchableWithoutFeedback = ({ onPress, onPressIn, ...props }) => {
   );
 };
 
+TouchableWithoutFeedback.defaultProps = {};
+
 TouchableWithoutFeedback.propTypes = {
   onPress: PropTypes.func,
   onPressIn: PropTypes.func,
-  children: PropTypes.node,
+  children: PropTypes.element.isRequired,
 };
 
 export default TouchableWithoutFeedback;

--- a/src/components/TouchableWithoutFeedback.jsx
+++ b/src/components/TouchableWithoutFeedback.jsx
@@ -1,0 +1,49 @@
+import React, { useRef } from "react";
+import { TouchableWithoutFeedback as RNTouchableWithoutFeedback } from "react-native";
+
+import PropTypes from "prop-types";
+
+const TouchableWithoutFeedback = ({ onPress, onPressIn, ...props }) => {
+  const _touchActivatePositionRef = useRef(null);
+
+  function _onPressIn(e) {
+    const { pageX, pageY } = e.nativeEvent;
+
+    _touchActivatePositionRef.current = {
+      pageX,
+      pageY,
+    };
+
+    onPressIn?.(e);
+  }
+
+  function _onPress(e) {
+    const { pageX, pageY } = e.nativeEvent;
+
+    const absX = Math.abs(_touchActivatePositionRef.current.pageX - pageX);
+    const absY = Math.abs(_touchActivatePositionRef.current.pageY - pageY);
+
+    const dragged = absX > 2 || absY > 2;
+    if (!dragged) {
+      onPress?.(e);
+    }
+  }
+
+  return (
+    <RNTouchableWithoutFeedback
+      onPress={_onPress}
+      onPressIn={_onPressIn}
+      {...props}
+    >
+      {props.children}
+    </RNTouchableWithoutFeedback>
+  );
+};
+
+TouchableWithoutFeedback.propTypes = {
+  onPress: PropTypes.func,
+  onPressIn: PropTypes.func,
+  children: PropTypes.node,
+};
+
+export default TouchableWithoutFeedback;

--- a/storybook/stories/Touchable.stories.jsx
+++ b/storybook/stories/Touchable.stories.jsx
@@ -18,7 +18,7 @@ export const Touchables = () => (
       bg="background.secondary"
       height="30px"
       justifyContent="center"
-      rippleContainerBorderRadius={50}
+      rippleConfig={{ containerBorderRadius: 50 }}
       width="100px"
     >
       <Typography fontSize="14px">Touchable</Typography>
@@ -30,7 +30,7 @@ export const Touchables = () => (
       height="30px"
       justifyContent="center"
       mt={10}
-      rippleContainerBorderRadius={50}
+      rippleConfig={{ containerBorderRadius: 50 }}
       width="200px"
     >
       <Typography fontSize="14px">Touchable with elevation</Typography>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,6 @@ const babelLoaderConfiguration = {
     ),
     path.resolve(__dirname, "./node_modules/react-native-pell-rich-editor"),
     path.resolve(__dirname, "./node_modules/react-native-webview"),
-    path.resolve(__dirname, "./node_modules/react-native-material-ripple"),
     path.resolve(__dirname, "./node_modules/react-native-calendars"),
   ],
   use: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15277,13 +15277,6 @@ react-native-gesture-handler@^2.4.0:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
-react-native-material-ripple@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/react-native-material-ripple/-/react-native-material-ripple-0.9.1.tgz#db1ad9dd7cf97011e4cd8475ae2041ade0f891cb"
-  integrity sha512-dHjARdKoGD3LXwPh2TkURabywM5BfdpKc/AHplJTfBMalhVZ2bc7iJoJmNhNnmT/TZ+B3szL6uV1mO7Pv8zNeA==
-  dependencies:
-    prop-types "^15.5.10"
-
 react-native-modal-datetime-picker@^10.1.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-10.2.0.tgz#3ec5c299e8bdc9fd2ec0a1a6642a459c408b910f"


### PR DESCRIPTION
Fixes #550 

@sangameshsomawar @injas-bigbinary please review.

**Checklist**

- [x] I have performed a self-review of my code and tested well before raising the PR.
- [x] I have made corresponding changes to the documentation and `index.d.ts`.
- [x] I've verified the change via .yalc in neetoDesk, neetoInvoice, and neetoPlanner.

**Breaking Change**
@bigbinary/neeto-rn after this update all the apps using ripple props directly will have to use `rippleConfig` instead to pass on all ripple-specific props to the TouchableComponents.

BTW I have updated it for all the applications and raised PRs where ripple-related props were being used.

Example:
<img width="628" alt="Screenshot 2022-12-19 at 1 09 26 PM" src="https://user-images.githubusercontent.com/27726339/208372534-de4eb480-e9e6-435a-b21d-ad9ff5cc96d6.png">