### PR TITLE
removed reanimated plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,8 +7,7 @@ module.exports = api => {
         root: ["./"],
         alias: require("./aliases.json"),
       },
-    ],
-    ["react-native-reanimated/plugin"],
+    ]
   ];
   if (babelEnv === "production") {
     plugins.push("transform-remove-console");


### PR DESCRIPTION
- Fixes #617 

@sangameshsomawar _A please review

We have to remove reanimated plugin from neeto-ui-rn and neeto-commons-rn and set `BABEL_ENV=production` in host application for it to work correctly.