### PR TITLE
Fixed cannot read property snapToNext of null in OnBoarding

### DIFF
--- a/src/components/OnBoarding.jsx
+++ b/src/components/OnBoarding.jsx
@@ -57,7 +57,7 @@ export const OnBoarding = ({
 
   const handleOnPress = () => {
     if (activeIndex !== slides.length - 1) {
-      setTimeout(() => onBoardingRef.current.snapToNext(), 250);
+      setTimeout(() => onBoardingRef.current?.snapToNext(), 250);
       setActiveIndex(onBoardingRef.current._activeItem);
     } else onComplete();
   };

--- a/src/components/OnBoarding.jsx
+++ b/src/components/OnBoarding.jsx
@@ -57,7 +57,7 @@ export const OnBoarding = ({
 
   const handleOnPress = () => {
     if (activeIndex !== slides.length - 1) {
-      onBoardingRef.current.snapToNext();
+      setTimeout(() => onBoardingRef.current.snapToNext(), 250);
       setActiveIndex(onBoardingRef.current._activeItem);
     } else onComplete();
   };


### PR DESCRIPTION
- Fixes #640 

**Checklist**

- [x] I have performed a self-review of my code and tested well before raising the PR.
- [ ] I have made corresponding changes to the documentation and `index.d.ts`.
- [x] I've verified the change via .yalc in some neetoApp.  <!-- Might be needed in some scenarios, if you have tested in some neeto RN app then please mention it. -->

**Demo or Screenshots**

<!-- Please describe the current behavior that you are modifying, demo with audio will be useful in most cases -->
<!-- or you can also post before and after screenshots -->


**Breaking Change**

<!-- Incase of breaking changes, please inform  to @bigbinary/neeto-rn and explain the necessary steps to fix the break. You can explain via video or text. -->